### PR TITLE
2.2.1 — Pusher fix, token management, auth doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,38 @@ These options apply to all commands:
 
 ## Authentication
 
-Forge CLI supports multiple authentication methods for different workflows.
+The CLI uses **two credential types**. They serve different purposes and are stored in different places.
+
+| Credential | Scope | Used for |
+|---|---|---|
+| **CLI token** | Your Forge account | `forge sites`, `forge create`, org/project management, and resolving site tokens via the API |
+| **Site token** | A single site | `forge deploy`, `forge env`, `forge settings`, `forge versions`, and other site operations |
+
+**Storage:**
+
+- `~/.forge/credentials.json` — CLI token, cached site tokens, org context, deploy watch credentials (email login)
+- `forge.json` — linked site URL (`site`) and optional inline site token (`site_token`)
+- Environment — `FORGE_TOKEN` (CLI), `FORGE_SITE_TOKEN` (site)
+- Flags — `--token` (CLI), `--site-token` (site)
+
+### Which credential does each command need?
+
+| Commands | CLI token | Site token |
+|---|---|---|
+| `forge sites`, `forge create`, `forge org *`, `forge token *`, `forge projects *` | Required | — |
+| `forge deploy`, `forge env`, `forge settings`, `forge versions`, `forge rollback`, `forge usage` | For API lookup | Required (resolved automatically when possible) |
+| `forge destroy`, `forge info`, `forge redeploy`, `forge feedback *` | Required | Required (resolved automatically when possible) |
+
+Site tokens are resolved automatically when you have a CLI token and a linked site. You should not need to copy site tokens from the Forge dashboard for normal workflows.
 
 ### Interactive Login
 
 ```bash
-forge login                              # Prompts for email and password
+forge login                              # Prompts for email and password (recommended)
 forge login --email me@example.com       # Prompts for password only
 ```
+
+Email/password login caches site tokens and enables real-time deploy log streaming.
 
 ### Direct Token
 
@@ -63,19 +87,22 @@ forge login --with-token <cli-token>     # Store a pre-existing CLI token
 forge login --browser                    # Opens browser for authentication
 ```
 
+OAuth login stores a CLI token only. Run `forge add <site>` to cache site tokens, or use scoped CLI tokens for agents.
+
 ### Environment Variables
 
 For CI/CD pipelines and automation:
 
 ```bash
-export FORGE_TOKEN=<cli-token>           # CLI token for general access
-export FORGE_SITE_TOKEN=<site-token>     # Site token for deploy-only access
+export FORGE_TOKEN=<cli-token>           # CLI token — recommended for agents managing many sites
+export FORGE_SITE_TOKEN=<site-token>     # Site token — per-site deploy access
 ```
 
 ### Check Auth Status
 
 ```bash
-forge whoami                             # Show current user, token type, and org context
+forge whoami                             # Show CLI auth, org context, linked site, token sources
+forge auth doctor                        # Diagnose token resolution and deploy readiness
 ```
 
 ### Logout
@@ -146,7 +173,7 @@ forge sites --page 1 --limit 20         # Paginate results
 | Option | Description |
 |---|---|
 | `--environment <env>` | Filter by environment (`production`, `staging`, `development`) |
-| `--org <id>` | Filter by organisation ID (`personal` or `0` for personal sites) |
+| `--org <id>` | Filter by organisation ID (`personal` or `0` for personal sites). Defaults to active org from `forge org switch`. |
 | `--page <n>` | Page number (shows single page instead of all results) |
 | `--limit <n>` | Results per page (default: 100, max: 500) |
 
@@ -172,10 +199,12 @@ When `--project` is a name rather than a numeric ID, the CLI resolves it automat
 ### Link a Directory
 
 ```bash
-forge add my-site.getforge.io           # Link current directory to a site
+forge add my-site.getforge.io            # Validate site, link directory, cache site token
+forge add my-site.getforge.io --save-token   # Also write site token to forge.json (CI/agents)
+forge add my-site.getforge.io --org 123  # Look up site under a specific organisation
 ```
 
-This writes the site URL to `forge.json` so subsequent commands know which site to target.
+`forge add` writes the site URL to `forge.json`, validates the site exists via your CLI token, and caches the site token in credentials. Use `--save-token` when you want the site token committed to `forge.json` for CI pipelines.
 
 ### Site Info
 
@@ -249,6 +278,7 @@ forge deploy --no-watch                  # Skip real-time deploy tracking
 | `-m, --message <msg>` | Version description |
 | `-d, --directory <dir>` | Directory to deploy (overrides `forge.json`) |
 | `--no-watch` | Skip real-time deploy log streaming |
+| `--org <id>` | Organisation for site token lookup (defaults to active org from `forge org switch`) |
 
 Deploys create a zip archive of your project, upload it, and stream real-time build logs back to the terminal. Use `--no-watch` to fire and forget.
 
@@ -265,7 +295,7 @@ forge redeploy --delay 30                # Queue deploy with a 30 second delay
 | Option | Description |
 |---|---|
 | `-s, --site <site>` | Site name |
-| `--org <id>` | Organisation ID for site lookup (`personal` or `0` for personal) |
+| `--org <id>` | Organisation for site token lookup (defaults to active org from `forge org switch`) |
 | `--cache` | Redeploy current version without pulling from source |
 | `--delay <seconds>` | Delay deploy start by N seconds |
 
@@ -395,7 +425,7 @@ forge org switch --id 123                # Switch to an organisation
 forge org switch --id personal           # Switch back to personal context
 ```
 
-When you switch context, subsequent commands like `forge sites` and `forge create` operate within that organisation.
+When you switch context, subsequent commands like `forge sites`, `forge create`, `forge projects`, and site token lookup default to that organisation. Override with `--org` on any command.
 
 ## Projects (Folders)
 
@@ -478,14 +508,23 @@ Creates a `forge.json` in your project root:
 
 You can create a `.forgeignore` file with gitignore-style patterns to exclude files from deployment. This works alongside the `ignore` array in `forge.json`.
 
-### Site Resolution
+### Site and Token Resolution
 
-For commands that operate on a site, the target is resolved in this order:
+Two separate concepts apply to site-scoped commands:
+
+**1. Which site?** (identity)
 
 1. `--site` flag on the command
-2. `--site-token` global option
-3. `site` or `site_token` in `forge.json`
-4. Stored site tokens from login
+2. `site` in `forge.json`
+
+**2. Which site token?** (credential)
+
+1. `--site-token` flag or `FORGE_SITE_TOKEN` env
+2. `site_token` in `forge.json`
+3. Cached site tokens in credentials (from login or `forge add`)
+4. API lookup using your CLI token (respects org context from `forge org switch`)
+
+If token resolution fails, run `forge auth doctor` for actionable guidance.
 
 ## Output Modes
 
@@ -496,10 +535,22 @@ forge deploy --quiet                     # Minimal output, exit codes only
 
 All commands support `--json` and `--quiet`. JSON mode outputs structured data suitable for piping to `jq` or consuming from scripts and AI agents.
 
-## CI/CD Usage
+## CI/CD and Agent Usage
+
+**Recommended: one scoped CLI token for many sites**
+
+```bash
+forge token create --name "Deploy Agent" --scopes sites:deploy --site-ids 101,102,103
+export FORGE_TOKEN=<token>
+forge deploy --site my-site.getforge.io --json
+```
+
+After `forge org switch --id 123`, deploy and site commands automatically use that org for token lookup.
+
+**Alternative: per-site token in CI**
 
 ```yaml
-# GitHub Actions example
+# GitHub Actions — one CLI token, linked project
 - name: Deploy to Forge
   env:
     FORGE_TOKEN: ${{ secrets.FORGE_TOKEN }}
@@ -508,9 +559,8 @@ All commands support `--json` and `--quiet`. JSON mode outputs structured data s
     forge deploy --json
 ```
 
-For deploy-only access with a site token:
-
 ```yaml
+# GitHub Actions — site token only (no account access)
 - name: Deploy to Forge
   env:
     FORGE_SITE_TOKEN: ${{ secrets.FORGE_SITE_TOKEN }}
@@ -518,6 +568,8 @@ For deploy-only access with a site token:
     npm install -g @beachio/forge-cli
     forge deploy --json
 ```
+
+Use `forge auth doctor --json` in CI to verify token resolution before deploying.
 
 ### Exit Codes
 
@@ -536,6 +588,7 @@ For deploy-only access with a site token:
 | `forge login` | Authenticate with Forge |
 | `forge logout` | Clear stored credentials |
 | `forge whoami` | Show current auth status |
+| `forge auth doctor` | Diagnose auth and site token resolution |
 | `forge token create` | Create a scoped CLI token |
 | `forge token list` | List active CLI tokens |
 | `forge token revoke <id>` | Revoke a CLI token |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forge-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forge-cli",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beachio/forge-cli",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Command line interface for GetForge.com — deploy and manage your Forge sites from the terminal",
   "type": "module",
   "bin": {

--- a/src/auth/org-context.ts
+++ b/src/auth/org-context.ts
@@ -1,0 +1,37 @@
+import { getStoredCredentials } from './token-store.js';
+import { ValidationError } from '../utils/errors.js';
+
+export const ORG_OPTION_DESCRIPTION =
+  'Organisation ID for site lookup (use "personal" or "0" for personal sites). Defaults to active org from `forge org switch`.';
+
+export function validateOrgOption(org: string | undefined): void {
+  if (org !== undefined && org !== 'personal' && org !== '0' && Number.isNaN(parseInt(org, 10))) {
+    throw new ValidationError('--org must be a numeric ID, "personal", or "0".', {});
+  }
+}
+
+/** Resolve org for API calls: explicit flag wins, then stored org context. */
+export function resolveOrganisationId(
+  explicitOrg?: string | number | null,
+): string | number | undefined {
+  if (explicitOrg !== undefined && explicitOrg !== null) {
+    return explicitOrg;
+  }
+  const stored = getStoredCredentials();
+  if (stored?.organisation_id != null) {
+    return stored.organisation_id;
+  }
+  return undefined;
+}
+
+export function organisationIdToQueryValue(orgId: string | number): string {
+  if (orgId === 'personal' || orgId === 0 || orgId === '0') return '0';
+  return String(orgId);
+}
+
+export function organisationIdToQuery(
+  orgId: string | number | undefined,
+): Record<string, string> | undefined {
+  if (orgId === undefined) return undefined;
+  return { organisation_id: organisationIdToQueryValue(orgId) };
+}

--- a/src/auth/resolver.ts
+++ b/src/auth/resolver.ts
@@ -1,6 +1,8 @@
 import { getStoredCredentials, type StoredCredentials } from './token-store.js';
 import { readForgeConfig } from '../config/forge-config.js';
 import { AuthError } from '../utils/errors.js';
+import { organisationIdToQuery, resolveOrganisationId } from './org-context.js';
+import { siteNotInAccountMessage } from '../utils/site-url-messages.js';
 
 export interface AuthContext {
   token: string;
@@ -44,7 +46,10 @@ export function resolveAuth(options: ResolveOptions = {}): AuthContext {
   throw new AuthError('Not authenticated. Run `forge login` to get started.');
 }
 
-function findSiteTokenByName(siteName: string, siteTokens: Record<string, string>): string | undefined {
+export function findSiteTokenByName(
+  siteName: string,
+  siteTokens: Record<string, string>,
+): string | undefined {
   const normalised = siteName.toLowerCase().replace(/\s+/g, '');
 
   const direct = siteTokens[siteName] || siteTokens[normalised];
@@ -63,7 +68,7 @@ function findSiteTokenByName(siteName: string, siteTokens: Record<string, string
   return undefined;
 }
 
-function normalizeSiteName(input: string): string {
+export function normalizeSiteName(input: string): string {
   return input
     .trim()
     .toLowerCase()
@@ -72,7 +77,7 @@ function normalizeSiteName(input: string): string {
     .replace(/\/+$/, '');
 }
 
-function siteNameMatches(targetSite: string, candidateUrl: string): boolean {
+export function siteNameMatches(targetSite: string, candidateUrl: string): boolean {
   const target = normalizeSiteName(targetSite);
   const candidate = normalizeSiteName(candidateUrl);
   if (!target || !candidate) return false;
@@ -93,12 +98,12 @@ function siteNameMatches(targetSite: string, candidateUrl: string): boolean {
   return false;
 }
 
-type SiteTokenLookupEntry = {
+export type SiteTokenLookupEntry = {
   url: string;
   site_token?: string;
 };
 
-function extractSiteTokenLookupEntries(raw: unknown): SiteTokenLookupEntry[] {
+export function extractSiteTokenLookupEntries(raw: unknown): SiteTokenLookupEntry[] {
   if (Array.isArray(raw)) {
     return raw
       .map((item) => {
@@ -138,31 +143,83 @@ function extractSiteTokenLookupEntries(raw: unknown): SiteTokenLookupEntry[] {
   return [];
 }
 
-export function resolveSiteToken(options: ResolveOptions = {}): string {
-  if (options.siteToken) return options.siteToken;
+export type SiteTokenSource =
+  | 'flag'
+  | 'env'
+  | 'config'
+  | 'login_cache'
+  | 'api_lookup'
+  | 'none';
+
+export function getLocalSiteTokenSource(options: {
+  siteToken?: string;
+  site?: string;
+}): { token?: string; source: SiteTokenSource } {
+  if (options.siteToken) {
+    return { token: options.siteToken, source: 'flag' };
+  }
 
   const envSiteToken = process.env.FORGE_SITE_TOKEN;
-  if (envSiteToken) return envSiteToken;
+  if (envSiteToken) {
+    return { token: envSiteToken, source: 'env' };
+  }
 
   const config = readForgeConfig();
-  if (config?.site_token) return config.site_token;
+  if (config?.site_token) {
+    return { token: config.site_token, source: 'config' };
+  }
 
   const stored = getStoredCredentials();
-  if (stored?.site_tokens) {
-    const siteName = config?.site;
-    if (siteName) {
-      const found = findSiteTokenByName(siteName, stored.site_tokens);
-      if (found) return found;
+  const siteName = options.site || config?.site;
+  if (stored?.site_tokens && siteName) {
+    const found = findSiteTokenByName(siteName, stored.site_tokens);
+    if (found) {
+      return { token: found, source: 'login_cache' };
     }
   }
 
+  return { source: 'none' };
+}
+
+export function resolveSiteToken(options: ResolveOptions = {}): string {
+  const local = getLocalSiteTokenSource(options);
+  if (local.token) return local.token;
+
   throw new AuthError(
-    'No site token found. Link a site with `forge add <site>` or provide --site-token.',
+    'No site token found locally. Provide --site-token, set FORGE_SITE_TOKEN, add site_token to forge.json, or run `forge add <site>` to cache one with your CLI token.',
   );
 }
 
+export async function fetchSiteList(options: {
+  token?: string;
+  organisationId?: string | number | null;
+}): Promise<SiteTokenLookupEntry[]> {
+  const auth = resolveAuth({ token: options.token });
+  const { getApiClient } = await import('../api/client.js');
+  const { API_PATHS } = await import('../config/constants.js');
+  const client = getApiClient();
+  const orgId = resolveOrganisationId(options.organisationId);
+  const query = organisationIdToQuery(orgId);
+
+  const raw = await client.get<unknown>(API_PATHS.sites, {
+    token: auth.token,
+    query,
+  });
+
+  return extractSiteTokenLookupEntries(raw);
+}
+
+export async function lookupSiteViaApi(options: {
+  siteName: string;
+  token?: string;
+  organisationId?: string | number | null;
+}): Promise<SiteTokenLookupEntry | undefined> {
+  const sites = await fetchSiteList(options);
+  return sites.find((site) => siteNameMatches(options.siteName, site.url));
+}
+
 export async function resolveSiteTokenWithFallback(
-  options: ResolveOptions & { site?: string; organisationId?: string | number } = {},
+  options: ResolveOptions & { site?: string; organisationId?: string | number | null } = {},
 ): Promise<string> {
   try {
     return resolveSiteToken(options);
@@ -173,35 +230,41 @@ export async function resolveSiteTokenWithFallback(
   const siteName = options.site || readForgeConfig()?.site;
   if (!siteName) {
     throw new AuthError(
-      'No site token found. Use --site <name>, --site-token <token>, or run `forge add <site>`.',
+      'No site token found. Specify the target site with --site, link the directory with `forge add <site>`, or provide --site-token.',
     );
   }
 
-  const auth = resolveAuth({ token: options.token });
-  const { getApiClient } = await import('../api/client.js');
-  const { API_PATHS } = await import('../config/constants.js');
-  const client = getApiClient();
-  const query: Record<string, string> | undefined =
-    options.organisationId !== undefined
-      ? {
-          organisation_id:
-            options.organisationId === 'personal' || options.organisationId === 0
-              ? '0'
-              : String(options.organisationId),
-        }
-      : undefined;
-  const raw = await client.get<unknown>(
-    API_PATHS.sites,
-    { token: auth.token, query },
-  );
+  const orgId = resolveOrganisationId(options.organisationId);
+  const match = await lookupSiteViaApi({
+    siteName,
+    token: options.token,
+    organisationId: orgId,
+  });
 
-  const sites = extractSiteTokenLookupEntries(raw);
-  const match = sites.find((site) => siteNameMatches(siteName, site.url));
   if (match?.site_token) return match.site_token;
 
   throw new AuthError(
-    `Could not find site token for "${siteName}". Check the site name or provide --site-token.`,
+    siteNotInAccountMessage(siteName, { orgFiltered: orgId !== undefined }),
   );
+}
+
+export function mergeSiteTokenIntoCredentials(
+  url: string,
+  siteToken: string,
+  stored?: StoredCredentials,
+): StoredCredentials {
+  const current = stored ?? getStoredCredentials();
+  if (!current) {
+    throw new AuthError('Not authenticated. Run `forge login` to get started.');
+  }
+
+  return {
+    ...current,
+    site_tokens: {
+      ...(current.site_tokens ?? {}),
+      [url]: siteToken,
+    },
+  };
 }
 
 export function requireAuth(options: ResolveOptions = {}): AuthContext {
@@ -214,4 +277,11 @@ export function getOptionalAuth(options: ResolveOptions = {}): AuthContext | und
   } catch {
     return undefined;
   }
+}
+
+export function inferLoginMethod(stored?: StoredCredentials): 'email' | 'oauth' | 'with-token' | 'unknown' {
+  if (!stored) return 'unknown';
+  if (stored.user_email || stored.site_tokens) return 'email';
+  if (stored.expires_at) return 'oauth';
+  return 'with-token';
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,23 +1,82 @@
 import { Command } from 'commander';
 import { writeForgeConfig, readForgeConfig } from '../config/forge-config.js';
+import {
+  resolveAuth,
+  lookupSiteViaApi,
+  mergeSiteTokenIntoCredentials,
+} from '../auth/resolver.js';
+import { getStoredCredentials, storeCredentials } from '../auth/token-store.js';
+import { ORG_OPTION_DESCRIPTION, resolveOrganisationId, validateOrgOption } from '../auth/org-context.js';
+import { AuthError } from '../utils/errors.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
+import { siteNotInAccountMessage } from '../utils/site-url-messages.js';
 
 export function registerAddCommand(program: Command): void {
   program
     .command('add <site>')
     .description('Link the current directory to a remote Forge site')
-    .action(async (site: string) => {
-      const existing = readForgeConfig() || {};
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
+    .option('--save-token', 'Write the site token to forge.json (useful for CI and agents)')
+    .action(async (site: string, options, cmd) => {
+      const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
 
-      writeForgeConfig({
-        ...existing,
-        site,
-      });
+      const spin = logger.spinner(`Linking to "${site}"...`);
 
-      handleCommandResult(
-        { success: true, site, directory: process.cwd() },
-        `Linked to "${site}". Deploy with \`forge deploy\`.`,
-      );
+      try {
+        resolveAuth({ token: parentOpts.token });
+
+        const match = await lookupSiteViaApi({
+          siteName: site,
+          token: parentOpts.token,
+          organisationId: options.org,
+        });
+
+        if (!match?.site_token) {
+          spin.stop();
+          throw new AuthError(
+            siteNotInAccountMessage(site, {
+              orgFiltered: resolveOrganisationId(options.org) !== undefined,
+            }),
+          );
+        }
+
+        const matchedUrl = match.url;
+        const siteToken = match.site_token;
+
+        storeCredentials(
+          mergeSiteTokenIntoCredentials(matchedUrl, siteToken, getStoredCredentials()),
+        );
+
+        const existing = readForgeConfig() || {};
+        writeForgeConfig({
+          ...existing,
+          site: matchedUrl,
+          ...(options.saveToken ? { site_token: siteToken } : {}),
+        });
+
+        spin.stop();
+
+        handleCommandResult(
+          {
+            success: true,
+            site: matchedUrl,
+            directory: process.cwd(),
+            token_cached: true,
+            token_saved_to_config: Boolean(options.saveToken),
+          },
+          [
+            `Linked to "${matchedUrl}". Site token cached in credentials.`,
+            options.saveToken ? 'Site token saved to forge.json.' : undefined,
+            'Deploy with `forge deploy`.',
+          ]
+            .filter(Boolean)
+            .join(' '),
+        );
+      } catch (err) {
+        spin.stop();
+        throw err;
+      }
     });
 }

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -1,0 +1,229 @@
+import { Command } from 'commander';
+import { readForgeConfig } from '../../config/forge-config.js';
+import { getStoredCredentials } from '../../auth/token-store.js';
+import {
+  getLocalSiteTokenSource,
+  getOptionalAuth,
+  inferLoginMethod,
+  lookupSiteViaApi,
+  resolveSiteTokenWithFallback,
+} from '../../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, resolveOrganisationId, validateOrgOption } from '../../auth/org-context.js';
+import { siteNotInAccountSuggestion, toForgeSiteUrl } from '../../utils/site-url-messages.js';
+import * as logger from '../../utils/logger.js';
+import { handleCommandResult } from '../../utils/output.js';
+
+type CheckStatus = 'pass' | 'warn' | 'fail';
+
+interface AuthCheck {
+  id: string;
+  status: CheckStatus;
+  message: string;
+  suggestion?: string;
+}
+
+export function registerAuthDoctorCommand(authCmd: Command): void {
+  authCmd
+    .command('doctor')
+    .description('Diagnose authentication, org context, and site token resolution')
+    .option('-s, --site <site>', 'Site to diagnose (defaults to forge.json site)')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
+    .action(async (options, cmd) => {
+      const parentOpts = cmd.parent?.parent?.opts() || cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
+
+      const checks: AuthCheck[] = [];
+      const stored = getStoredCredentials();
+      const config = readForgeConfig();
+      const targetSite = options.site || config?.site;
+      const orgId = resolveOrganisationId(options.org);
+
+      const auth = getOptionalAuth({
+        token: parentOpts.token,
+        siteToken: parentOpts.siteToken,
+      });
+
+      if (!auth || auth.tokenType !== 'cli') {
+        checks.push({
+          id: 'cli_auth',
+          status: 'fail',
+          message: auth?.tokenType === 'site'
+            ? 'Only a site token is configured; account commands need a CLI token.'
+            : 'No CLI token found.',
+          suggestion: 'Run `forge login` or set FORGE_TOKEN.',
+        });
+      } else {
+        checks.push({
+          id: 'cli_auth',
+          status: 'pass',
+          message: `CLI token present (${auth.source}).`,
+        });
+
+        const loginMethod = inferLoginMethod(stored);
+        if (loginMethod === 'oauth' || loginMethod === 'with-token') {
+          checks.push({
+            id: 'login_method',
+            status: 'warn',
+            message:
+              loginMethod === 'oauth'
+                ? 'Browser/OAuth login does not cache site tokens or deploy watch credentials.'
+                : 'Direct token login does not cache site tokens from your account.',
+            suggestion:
+              'Use email/password login for cached site tokens, or run `forge add <site>` to cache tokens.',
+          });
+        } else if (loginMethod === 'email') {
+          checks.push({
+            id: 'login_method',
+            status: 'pass',
+            message: 'Email login with cached account metadata.',
+          });
+        }
+      }
+
+      if (stored?.organisation_id) {
+        checks.push({
+          id: 'org_context',
+          status: 'pass',
+          message: `Org context: ${stored.organisation_name} (ID: ${stored.organisation_id}).`,
+        });
+      } else {
+        checks.push({
+          id: 'org_context',
+          status: 'pass',
+          message: 'Org context: Personal.',
+        });
+      }
+
+      if (config?.site) {
+        checks.push({
+          id: 'project_link',
+          status: 'pass',
+          message: `Project linked: ${config.site}.`,
+        });
+      } else if (targetSite) {
+        checks.push({
+          id: 'project_link',
+          status: 'pass',
+          message: `Target site: ${targetSite} (from --site).`,
+        });
+      } else {
+        checks.push({
+          id: 'project_link',
+          status: 'warn',
+          message: 'No linked site in forge.json.',
+          suggestion: 'Run `forge add <site>` from your project directory.',
+        });
+      }
+
+      if (targetSite) {
+        const local = getLocalSiteTokenSource({
+          siteToken: parentOpts.siteToken,
+          site: targetSite,
+        });
+
+        if (local.token) {
+          checks.push({
+            id: 'site_token_local',
+            status: 'pass',
+            message: `Site token available locally (${local.source}).`,
+          });
+        } else {
+          checks.push({
+            id: 'site_token_local',
+            status: 'warn',
+            message: 'No local site token for the linked site.',
+            suggestion: 'Run `forge add <site>` or provide --site-token / FORGE_SITE_TOKEN.',
+          });
+        }
+
+        if (auth?.tokenType === 'cli') {
+          try {
+            await resolveSiteTokenWithFallback({
+              token: parentOpts.token,
+              siteToken: parentOpts.siteToken,
+              site: targetSite,
+              organisationId: options.org,
+            });
+            checks.push({
+              id: 'site_token_lookup',
+              status: 'pass',
+              message: 'Site token resolvable via CLI token (including API lookup).',
+            });
+          } catch {
+            const apiMatch = await lookupSiteViaApi({
+              siteName: targetSite,
+              token: parentOpts.token,
+              organisationId: orgId,
+            }).catch(() => undefined);
+
+            if (apiMatch?.site_token) {
+              checks.push({
+                id: 'site_token_lookup',
+                status: 'pass',
+                message: 'Site token found via API lookup.',
+              });
+            } else {
+              checks.push({
+                id: 'site_token_lookup',
+                status: 'fail',
+                message: `Site ${toForgeSiteUrl(targetSite)} is not accessible under your CLI token.`,
+                suggestion: siteNotInAccountSuggestion(targetSite),
+              });
+              checks.push({
+                id: 'url_ownership',
+                status: 'warn',
+                message:
+                  'If `forge create` reports this URL as already in use, another Forge account likely owns that globally unique subdomain.',
+                suggestion:
+                  'Create a new site with a unique name: `forge create --name <name>-<suffix>`.',
+              });
+            }
+          }
+        }
+      }
+
+      const deployReady = Boolean(
+        auth?.tokenType === 'cli' &&
+          targetSite &&
+          (checks.some((c) => c.id === 'site_token_local' && c.status === 'pass') ||
+            checks.some((c) => c.id === 'site_token_lookup' && c.status === 'pass')),
+      );
+
+      const result = {
+        checks,
+        deploy_ready: Boolean(deployReady),
+        linked_site: config?.site ?? null,
+        target_site: targetSite ?? null,
+        organisation_id: stored?.organisation_id ?? null,
+        organisation_name: stored?.organisation_name ?? null,
+      };
+
+      handleCommandResult(result);
+
+      if (logger.getOutputMode() === 'human') {
+        logger.info('');
+        for (const check of checks) {
+          const icon =
+            check.status === 'pass' ? logger.statusBadge('success') :
+            check.status === 'warn' ? logger.statusBadge('queued') :
+            logger.statusBadge('failed');
+          logger.info(`${icon} ${check.message}`);
+          if (check.suggestion) {
+            logger.dim(`    → ${check.suggestion}`);
+          }
+        }
+        logger.info('');
+        if (deployReady) {
+          logger.success('Ready to deploy: `forge deploy`');
+        } else {
+          logger.warn('Not ready to deploy yet. Address the items above.');
+        }
+      }
+    });
+}
+
+export function registerAuthCommands(program: Command): void {
+  const authCmd = program.command('auth').description('Authentication diagnostics and utilities');
+
+  registerAuthDoctorCommand(authCmd);
+}

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,8 +2,15 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveAuth } from '../auth/resolver.js';
+import {
+  organisationIdToQuery,
+  resolveOrganisationId,
+  validateOrgOption,
+} from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
+import { ValidationError } from '../utils/errors.js';
+import { isUrlAlreadyInUseMessage, urlAlreadyInUseMessage } from '../utils/site-url-messages.js';
 import { displayDnsInstructions, type DnsInstructions } from '../utils/dns-instructions.js';
 import type { ProjectsResponse } from '../api/endpoints.js';
 
@@ -40,6 +47,7 @@ export function registerCreateCommand(program: Command): void {
     .option('--project <id|name>', 'Add site to a project (folder) by ID or name')
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const auth = resolveAuth({ token: parentOpts.token });
 
       const name = options.name.toLowerCase().trim();
@@ -63,8 +71,10 @@ export function registerCreateCommand(program: Command): void {
           const lookupSpin = logger.spinner(`Looking up project "${options.project}"...`);
           try {
             const client = getApiClient();
+            const projectQuery = organisationIdToQuery(resolveOrganisationId(options.org));
             const projectsResponse = await client.get<ProjectsResponse>(API_PATHS.projects, {
               token: auth.token,
+              query: projectQuery,
             });
             lookupSpin.stop();
             const match = (projectsResponse.projects || []).find(
@@ -94,8 +104,14 @@ export function registerCreateCommand(program: Command): void {
         if (options.custom) {
           body.custom_domain = options.custom;
         }
-        if (options.org) {
-          body.organisation_id = parseInt(options.org, 10);
+        const orgId = resolveOrganisationId(options.org);
+        if (orgId !== undefined) {
+          body.organisation_id =
+            orgId === 'personal' || orgId === 0 || orgId === '0'
+              ? 0
+              : typeof orgId === 'number'
+                ? orgId
+                : parseInt(String(orgId), 10);
         }
 
         const response = await client.post<CreateSiteResponse>(API_PATHS.create, {
@@ -130,6 +146,7 @@ export function registerCreateCommand(program: Command): void {
               logger.info(`  SSL:        ${site.ssl ? 'on' : 'off'}`);
               logger.info('');
               logger.dim(`Link this directory: forge add ${site.url}`);
+              logger.dim(`For CI/agents: forge add ${site.url} --save-token`);
             }
             return;
           }
@@ -166,10 +183,14 @@ export function registerCreateCommand(program: Command): void {
             );
           } else {
             logger.dim(`Link this directory: forge add ${site.url}`);
+            logger.dim(`For CI/agents: forge add ${site.url} --save-token`);
           }
         }
       } catch (err) {
         spin.stop();
+        if (err instanceof ValidationError && isUrlAlreadyInUseMessage(err.message)) {
+          throw new ValidationError(urlAlreadyInUseMessage(name), err.details);
+        }
         throw err;
       }
     });

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import { getStoredCredentials } from '../auth/token-store.js';
 import { readForgeConfig } from '../config/forge-config.js';
 import { createDeployArchive } from '../utils/archive.js';
@@ -95,14 +96,17 @@ export function registerDeployCommand(program: Command): void {
     .option('-m, --message <message>', 'Version description')
     .option('-d, --directory <dir>', 'Directory to deploy')
     .option('--no-watch', 'Skip real-time deploy tracking')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
       const config = readForgeConfig();
+      validateOrgOption(options.org);
 
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const deployDir = resolve(options.directory || config?.deploy_directory || '.');

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveAuth, resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -16,13 +17,16 @@ export function registerDestroyCommand(program: Command): void {
     .description('Permanently delete a Forge site')
     .option('-s, --site <site>', 'Site name')
     .option('--force', 'Skip confirmation prompt')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const auth = resolveAuth({ token: parentOpts.token });
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       if (!options.force) {

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -14,12 +15,15 @@ export function registerEnvCommands(program: Command): void {
     .command('env')
     .description('Manage environment variables for a site')
     .option('-s, --site <site>', 'Site name')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const spin = logger.spinner('Fetching environment variables...');
@@ -60,14 +64,17 @@ export function registerEnvCommands(program: Command): void {
     .command('set')
     .description('Set environment variables (KEY=VALUE pairs)')
     .option('-s, --site <site>', 'Site name')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .argument('<pairs...>', 'KEY=VALUE pairs to set')
     .action(async (pairs: string[], options, cmd) => {
       const parentOpts = cmd.parent?.parent?.opts() || {};
       const envOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org ?? envOpts.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site || envOpts.site,
+        organisationId: options.org ?? envOpts.org,
       });
 
       const vars: Record<string, string> = {};
@@ -110,14 +117,17 @@ export function registerEnvCommands(program: Command): void {
     .command('unset')
     .description('Remove environment variables by key')
     .option('-s, --site <site>', 'Site name')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .argument('<keys...>', 'Variable names to remove')
     .action(async (keys: string[], options, cmd) => {
       const parentOpts = cmd.parent?.parent?.opts() || {};
       const envOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org ?? envOpts.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site || envOpts.site,
+        organisationId: options.org ?? envOpts.org,
       });
 
       const spin = logger.spinner('Removing environment variables...');

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
-import { resolveAuth } from '../auth/resolver.js';
-import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { resolveAuth, resolveSiteTokenWithFallback, siteNameMatches } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import { readForgeConfig } from '../config/forge-config.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
@@ -53,8 +53,10 @@ export function registerInfoCommand(program: Command): void {
     .command('info')
     .description('Show detailed information about a site')
     .option('-s, --site <site>', 'Site name')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const config = readForgeConfig();
       const siteName = options.site || config?.site;
 
@@ -67,6 +69,7 @@ export function registerInfoCommand(program: Command): void {
           siteToken: parentOpts.siteToken,
           token: parentOpts.token,
           site: options.site,
+          organisationId: options.org,
         }).catch(() => undefined);
 
         if (siteToken) {
@@ -87,17 +90,17 @@ export function registerInfoCommand(program: Command): void {
         if (!siteInfo && siteName) {
           const auth = resolveAuth({ token: parentOpts.token });
           const client = getApiClient();
+          const { organisationIdToQuery, resolveOrganisationId } = await import('../auth/org-context.js');
           const raw = await client.get<{ sites: SiteInfoResponse[] }>(
             API_PATHS.sites,
-            { token: auth.token },
+            {
+              token: auth.token,
+              query: organisationIdToQuery(resolveOrganisationId(options.org)),
+            },
           );
 
           if (raw.sites) {
-            const name = siteName.toLowerCase();
-            siteInfo = raw.sites.find((s) => {
-              const url = (s.url || '').toLowerCase();
-              return url === name || url === `${name}.getforge.io` || url.startsWith(`${name}.`);
-            });
+            siteInfo = raw.sites.find((s) => siteNameMatches(siteName, s.url || ''));
           }
         }
 

--- a/src/commands/projects/index.ts
+++ b/src/commands/projects/index.ts
@@ -3,6 +3,11 @@ import inquirer from 'inquirer';
 import { getApiClient } from '../../api/client.js';
 import { API_PATHS } from '../../config/constants.js';
 import { resolveAuth } from '../../auth/resolver.js';
+import {
+  organisationIdToQuery,
+  resolveOrganisationId,
+  validateOrgOption,
+} from '../../auth/org-context.js';
 import * as logger from '../../utils/logger.js';
 import { handleCommandResult } from '../../utils/output.js';
 import type { ProjectsResponse, ProjectResponse, Project } from '../../api/endpoints.js';
@@ -58,17 +63,17 @@ export function registerProjectCommands(program: Command): void {
   program
     .command('projects')
     .description('List your projects (folders)')
-    .option('--org <id>', 'Filter by organisation ID')
+    .option('--org <id>', 'Filter by organisation ID (defaults to active org from `forge org switch`)')
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const auth = resolveAuth({ token: parentOpts.token });
 
       const spin = logger.spinner('Fetching projects...');
 
       try {
         const client = getApiClient();
-        const query: Record<string, string> = {};
-        if (options.org) query.organisation_id = options.org;
+        const query = organisationIdToQuery(resolveOrganisationId(options.org)) ?? {};
 
         const response = await client.get<ProjectsResponse>(API_PATHS.projects, {
           token: auth.token,

--- a/src/commands/redeploy.ts
+++ b/src/commands/redeploy.ts
@@ -3,6 +3,7 @@ import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
 import type { RedeployResponse, RedeployDetail } from '../api/endpoints.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import { ValidationError } from '../utils/errors.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
@@ -19,21 +20,18 @@ export function registerRedeployCommand(program: Command): void {
     .command('redeploy')
     .description('Redeploy site from connected source provider')
     .option('-s, --site <site>', 'Site name')
-    .option('--org <id>', 'Organisation ID for site lookup (use "personal" or "0" for personal sites)')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .option('--cache', 'Redeploy current version without pulling from source')
     .option('--delay <seconds>', 'Delay deploy start by N seconds')
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
-      const org = options.org as string | undefined;
-      if (org !== undefined && org !== 'personal' && org !== '0' && Number.isNaN(parseInt(org, 10))) {
-        throw new ValidationError('--org must be a numeric ID, "personal", or "0".', {});
-      }
+      validateOrgOption(options.org);
 
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
-        organisationId: org,
+        organisationId: options.org,
       });
 
       let delay: number | undefined;

--- a/src/commands/rollback.ts
+++ b/src/commands/rollback.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import { ValidationError } from '../utils/errors.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
@@ -24,12 +25,15 @@ export function registerRollbackCommand(program: Command): void {
     .description('Rollback site to a previous version')
     .option('-s, --site <site>', 'Site name')
     .requiredOption('--version-id <id>', 'Version ID to rollback to (from `forge versions` output)')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const versionId = parseInt(options.versionId, 10);

--- a/src/commands/settings/index.ts
+++ b/src/commands/settings/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApiClient } from '../../api/client.js';
 import { API_PATHS } from '../../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../../auth/org-context.js';
 import * as logger from '../../utils/logger.js';
 import { handleCommandResult } from '../../utils/output.js';
 
@@ -28,12 +29,15 @@ export function registerSettingsCommands(program: Command): void {
     .option('--build-command <cmd>', 'Custom build command (e.g. "npm run build")')
     .option('--build-folder <folder>', 'Build output folder (e.g. "dist")')
     .option('--squish <on|off>', 'Enable or disable TurboJS minification')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const body: Record<string, unknown> = { site_token: siteToken };

--- a/src/commands/sites.ts
+++ b/src/commands/sites.ts
@@ -2,6 +2,11 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveAuth } from '../auth/resolver.js';
+import {
+  organisationIdToQuery,
+  resolveOrganisationId,
+  validateOrgOption,
+} from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -38,6 +43,7 @@ export function registerSitesCommand(program: Command): void {
     .option('--limit <n>', 'Results per page (default: 100, max: 500)')
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const auth = resolveAuth({ token: parentOpts.token });
 
       const spin = logger.spinner('Fetching sites...');
@@ -46,10 +52,8 @@ export function registerSitesCommand(program: Command): void {
         const client = getApiClient();
         const query: Record<string, string> = {};
         if (options.environment) query.environment = options.environment;
-        if (options.org != null) {
-          const orgVal = options.org === 'personal' ? '0' : options.org;
-          query.organisation_id = orgVal;
-        }
+        const orgQuery = organisationIdToQuery(resolveOrganisationId(options.org));
+        if (orgQuery) Object.assign(query, orgQuery);
         if (options.limit) query.limit = options.limit;
 
         const explicitPage = options.page != null;

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -46,12 +47,15 @@ export function registerUsageCommand(program: Command): void {
     .description('Show bandwidth and build usage for a site')
     .option('-s, --site <site>', 'Site name')
     .option('--days <n>', 'Days of daily breakdown (default: 30, max: 365)')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const spin = logger.spinner('Fetching usage data...');

--- a/src/commands/versions.ts
+++ b/src/commands/versions.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { getApiClient } from '../api/client.js';
 import { API_PATHS } from '../config/constants.js';
 import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -46,12 +47,15 @@ export function registerVersionsCommand(program: Command): void {
     .option('-s, --site <site>', 'Site name')
     .option('--limit <n>', 'Versions per page (default: 20, max: 100)')
     .option('--page <n>', 'Page number')
+    .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
+      validateOrgOption(options.org);
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
         token: parentOpts.token,
         site: options.site,
+        organisationId: options.org,
       });
 
       const spin = logger.spinner('Fetching versions...');

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,6 +1,11 @@
 import { Command } from 'commander';
-import { getStoredCredentials, hasStoredCredentials } from '../auth/token-store.js';
-import { getOptionalAuth } from '../auth/resolver.js';
+import { getStoredCredentials } from '../auth/token-store.js';
+import { readForgeConfig } from '../config/forge-config.js';
+import {
+  getLocalSiteTokenSource,
+  getOptionalAuth,
+  inferLoginMethod,
+} from '../auth/resolver.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 
@@ -21,15 +26,25 @@ export function registerWhoamiCommand(program: Command): void {
       }
 
       const stored = getStoredCredentials();
+      const config = readForgeConfig();
+      const loginMethod = inferLoginMethod(stored);
+      const cachedSiteTokens = stored?.site_tokens ? Object.keys(stored.site_tokens).length : 0;
+      const linkedSite = config?.site;
+      const localSiteToken = linkedSite
+        ? getLocalSiteTokenSource({ site: linkedSite, siteToken: parentOpts.siteToken })
+        : { source: 'none' as const };
 
       const info = {
         authenticated: true,
         token_type: auth.tokenType,
         source: auth.source,
+        login_method: loginMethod,
         user_email: stored?.user_email,
         user_name: stored?.user_name,
         expires_at: stored?.expires_at,
-        has_site_tokens: stored?.site_tokens ? Object.keys(stored.site_tokens).length : 0,
+        cached_site_tokens: cachedSiteTokens,
+        linked_site: linkedSite ?? null,
+        linked_site_token_source: linkedSite ? localSiteToken.source : null,
         organisation_id: stored?.organisation_id ?? null,
         organisation_name: stored?.organisation_name ?? null,
       };
@@ -39,6 +54,7 @@ export function registerWhoamiCommand(program: Command): void {
       if (logger.getOutputMode() === 'human') {
         logger.info(`  Token type:  ${auth.tokenType}`);
         logger.info(`  Source:      ${auth.source}`);
+        logger.info(`  Login:       ${loginMethod}`);
         if (stored?.user_email) logger.info(`  Email:       ${stored.user_email}`);
         if (stored?.user_name) logger.info(`  User:        ${stored.user_name}`);
         if (stored?.organisation_id) {
@@ -47,8 +63,16 @@ export function registerWhoamiCommand(program: Command): void {
           logger.info(`  Context:     Personal`);
         }
         if (stored?.expires_at) logger.info(`  Expires:     ${stored.expires_at}`);
-        if (stored?.site_tokens) {
-          logger.info(`  Sites:       ${Object.keys(stored.site_tokens).length} linked`);
+        logger.info(`  Cached site tokens: ${cachedSiteTokens} (from login/add)`);
+        if (linkedSite) {
+          logger.info(`  Linked site: ${linkedSite}`);
+          if (localSiteToken.source === 'none') {
+            logger.warn(
+              '  No local site token for linked site. Run `forge add <site>` or `forge auth doctor`.',
+            );
+          } else {
+            logger.info(`  Site token:  available (${localSiteToken.source})`);
+          }
         }
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { registerDomainCommands } from './commands/domain/index.js';
 import { registerOrgCommands } from './commands/org/index.js';
 import { registerProjectCommands } from './commands/projects/index.js';
 import { registerFeedbackCommands } from './commands/feedback/index.js';
+import { registerAuthCommands } from './commands/auth/index.js';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -71,6 +72,7 @@ export function createProgram(): Command {
   registerOrgCommands(program);
   registerProjectCommands(program);
   registerFeedbackCommands(program);
+  registerAuthCommands(program);
 
   program.exitOverride((err) => {
     if (err.code === 'commander.version' || err.code === 'commander.helpDisplayed') {

--- a/src/realtime/pusher-client.ts
+++ b/src/realtime/pusher-client.ts
@@ -1,6 +1,10 @@
-import Pusher from 'pusher-js';
+import PusherImport from 'pusher-js';
 import type { Channel } from 'pusher-js';
 import type { DeployLogEvent, VersionUpdateEvent, SiteUpdateEvent } from './types.js';
+
+// pusher-js is CJS; default ESM interop can yield the module namespace instead of
+// the constructor, which surfaces as "Pusher is not a constructor" at runtime.
+const Pusher = PusherImport.default ?? PusherImport;
 
 export interface DeployEventHandlers {
   onLog: (event: DeployLogEvent) => void;

--- a/src/utils/site-url-messages.ts
+++ b/src/utils/site-url-messages.ts
@@ -1,0 +1,85 @@
+/** Normalize a site name or URL to a full Forge site URL for display. */
+export function toForgeSiteUrl(name: string): string {
+  const normalized = name
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/\/.*$/, '')
+    .replace(/\/+$/, '');
+
+  if (normalized.includes('.')) return normalized;
+  return `${normalized}.getforge.io`;
+}
+
+export function isUrlAlreadyInUseMessage(message: string): boolean {
+  return /url.*already.*in use|already.*in use|name.*taken|url.*taken/i.test(message);
+}
+
+/** Suggest a likely-unique site name slug from an taken name. */
+export function suggestUniqueSiteName(baseName: string): string {
+  const slug = baseName
+    .replace(/\.getforge\.io$/i, '')
+    .replace(/-\d{6,}$/, '')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  const suffix = Date.now().toString().slice(-6);
+  const candidate = `${slug}-${suffix}`;
+  return candidate.length >= 3 ? candidate : `site-${suffix}`;
+}
+
+export function urlAlreadyInUseMessage(siteName: string): string {
+  const url = toForgeSiteUrl(siteName);
+  const suggestion = suggestUniqueSiteName(siteName);
+
+  return [
+    `The URL ${url} is already taken on Forge.`,
+    '',
+    'Forge site URLs are globally unique across all accounts. This subdomain is not available to you — it may belong to another user or organisation, or be reserved from a previous site.',
+    '',
+    'Choose a different name, for example:',
+    `  forge create --name ${suggestion}`,
+  ].join('\n');
+}
+
+export function siteNotInAccountMessage(
+  siteName: string,
+  options: { orgFiltered?: boolean } = {},
+): string {
+  const url = toForgeSiteUrl(siteName);
+
+  const lines = [
+    `Site ${url} is not in your account.`,
+    '',
+    'You can only deploy to sites your CLI token can access. Common causes:',
+    '  • The URL is owned by another Forge account (URLs are globally unique)',
+    '  • The site is under a different organisation',
+    '  • The name in forge.json is outdated or misspelled',
+  ];
+
+  if (options.orgFiltered) {
+    lines.push('  • Your active org context is filtering it out — try `--org personal` or `--org <id>`');
+  }
+
+  lines.push(
+    '',
+    'If `forge create` says the URL is already in use but add/lookup cannot find it, another account likely owns that subdomain.',
+    '',
+    'Next steps:',
+    '  forge sites                    List sites you can access',
+    `  forge add ${url}               Link a site you own`,
+    '  forge create --name <unique>   Create a new site with a unique name',
+    '  forge auth doctor              Diagnose token and org context',
+  );
+
+  return lines.join('\n');
+}
+
+export function siteNotInAccountSuggestion(siteName: string): string {
+  const url = toForgeSiteUrl(siteName);
+  return [
+    `Verify you own ${url} with \`forge sites\`.`,
+    'If create says the URL is taken, another account likely owns it — pick a unique name.',
+    'Try `--org <id>` or `forge org switch` if the site is under a different organisation.',
+  ].join(' ');
+}


### PR DESCRIPTION
## Summary

- Fix Pusher ESM/CJS interop so default `forge deploy` watch mode works without `--no-watch`
- Improve multi-org token resolution: org-aware site token lookup, `--org` on site commands, org defaults on `sites`/`create`/`projects`
- Smarter `forge add` validates sites via API, caches tokens, and supports `--save-token` for CI
- Add `forge auth doctor` to diagnose auth, org context, and deploy readiness
- Clarify globally unique URL conflict messaging when create and add disagree about a URL
- Expand README auth documentation and improve `forge whoami` output

## Test plan

- [x] Live test: `forge create` → `forge add` → `forge auth doctor` → `forge deploy` from `test-site` (local 2.2.1 build)
- [x] Verified Pusher watch mode streams deploy progress without `--no-watch`
- [x] Verified improved error messages for taken URL (`forge create --name my-cli-site`) and not-in-account (`forge add`)
- [ ] Merge to `main` and publish `npm publish` from `main` (tag `v2.2.1` already pushed)


Made with [Cursor](https://cursor.com)