### PR TITLE
2.3.0: Direct S3 upload deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,10 @@ forge deploy --no-watch                  # Skip real-time deploy tracking
 | `-m, --message <msg>` | Version description |
 | `-d, --directory <dir>` | Directory to deploy (overrides `forge.json`) |
 | `--no-watch` | Skip real-time deploy log streaming |
+| `--legacy-upload` | Force legacy multipart upload via `api.getforge.com` (slower; fallback if direct upload unavailable) |
 | `--org <id>` | Organisation for site token lookup (defaults to active org from `forge org switch`) |
 
-Deploys create a zip archive of your project, upload it, and stream real-time build logs back to the terminal. Use `--no-watch` to fire and forget.
+Deploys create a zip archive, upload it directly to storage (same path as gleo.dev), then trigger processing on Forge. Real-time build logs stream back via Pusher. Use `--no-watch` to return after deploy is queued.
 
 ### Redeploy (from source)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beachio/forge-cli",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Command line interface for GetForge.com — deploy and manage your Forge sites from the terminal",
   "type": "module",
   "bin": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,7 @@ import {
   PlanLimitError,
   AccountLockedError,
   ForgeError,
+  ApiError,
 } from '../utils/errors.js';
 import type { ApiErrorResponse } from './endpoints.js';
 
@@ -114,6 +115,28 @@ export class ApiClient {
     return this.request<T>(path, { ...options, method: 'DELETE' });
   }
 
+  async head(path: string, options: Omit<RequestOptions, 'method' | 'body'> = {}): Promise<Response> {
+    const { headers = {}, token, query } = options;
+    const url = new URL(path, this.baseUrl);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        url.searchParams.set(key, value);
+      }
+    }
+
+    const requestHeaders: Record<string, string> = {
+      Accept: 'application/json',
+      'User-Agent': USER_AGENT,
+      ...headers,
+    };
+
+    if (token) {
+      requestHeaders['X-USER-TOKEN'] = token;
+    }
+
+    return fetch(url.toString(), { method: 'HEAD', headers: requestHeaders });
+  }
+
   private async handleErrorResponse(response: Response, responseText?: string): Promise<never> {
     let errorData: ApiErrorResponse | undefined;
 
@@ -152,7 +175,7 @@ export class ApiClient {
       }
 
       case 404:
-        throw new ForgeError(`Not found: ${message}`);
+        throw new ApiError(`Not found: ${message}`, 404);
 
       case 422:
         throw new ValidationError(message, errorData as unknown as Record<string, unknown>);

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -92,6 +92,39 @@ export interface DeployResponse {
   version?: number;
 }
 
+export interface DeployUploadTarget {
+  method: 'PUT' | 'POST';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface DeployInitResponse {
+  deploy_id: string;
+  version_id?: number | null;
+  upload: DeployUploadTarget;
+  expires_at?: string;
+  limits?: {
+    max_archive_size_bytes: number;
+    upload_expires_in_seconds: number;
+  };
+}
+
+export interface DeployCompleteResponse {
+  deploy: DeployDetail;
+  success?: boolean;
+  message?: string;
+}
+
+export interface DeployStatusResponse {
+  deploy_id: string;
+  status: string;
+  version_id?: number | null;
+  version_number?: number | null;
+  url?: string;
+  site_id?: number;
+  error?: string;
+}
+
 export interface RedeployDetail {
   site_id: number;
   url: string;

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,18 +1,24 @@
 import { Command } from 'commander';
-import { readFileSync, unlinkSync } from 'node:fs';
+import { unlinkSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getApiClient } from '../api/client.js';
-import { API_PATHS } from '../config/constants.js';
-import { resolveSiteTokenWithFallback } from '../auth/resolver.js';
+import { resolveAuth, resolveSiteTokenWithFallback } from '../auth/resolver.js';
 import { ORG_OPTION_DESCRIPTION, validateOrgOption } from '../auth/org-context.js';
 import { getStoredCredentials } from '../auth/token-store.js';
 import { readForgeConfig } from '../config/forge-config.js';
+import {
+  completeDirectDeploy,
+  deployViaLegacyMultipart,
+  initDirectDeploy,
+  isDirectUploadUnavailable,
+  uploadArchiveToPresignedUrl,
+} from '../deploy/direct-upload.js';
 import { createDeployArchive } from '../utils/archive.js';
 import * as logger from '../utils/logger.js';
 import { handleCommandResult } from '../utils/output.js';
 import { ForgePusherClient } from '../realtime/pusher-client.js';
 import { DeployRenderer } from '../realtime/deploy-renderer.js';
-import type { DeployResponse, DeployDetail } from '../api/endpoints.js';
+import type { DeployDetail, DeployResponse } from '../api/endpoints.js';
 import type { DeployLogEvent } from '../realtime/types.js';
 
 const DEPLOY_TIMEOUT_MS = 5 * 60 * 1000;
@@ -20,7 +26,7 @@ const DEPLOY_TIMEOUT_MS = 5 * 60 * 1000;
 /**
  * Attaches handlers to an already-subscribed Pusher client and waits for
  * a terminal deploy event. The client must have been subscribed (and
- * buffering events) before the deploy POST was issued.
+ * buffering events) before the deploy is triggered.
  */
 function watchDeploy(
   client: ForgePusherClient,
@@ -88,6 +94,83 @@ function watchDeploy(
   });
 }
 
+function formatDeploySuccess(deploy: DeployDetail): string {
+  return [
+    `Deployed Version #${deploy.version_number} to ${deploy.url}`,
+    logger.getOutputMode() === 'human'
+      ? `  Status: ${logger.statusBadge(deploy.status)} | Mode: ${deploy.mode}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function resolveDeployResponse(options: {
+  siteToken: string;
+  archivePath: string;
+  message?: string;
+  cliToken?: string;
+  legacyUpload: boolean;
+}): Promise<DeployResponse> {
+  const apiClient = getApiClient();
+
+  if (options.legacyUpload) {
+    return deployViaLegacyMultipart(apiClient, options);
+  }
+
+  try {
+    const init = await initDirectDeploy(apiClient, options);
+    await uploadArchiveToPresignedUrl(options.archivePath, init.upload);
+    const complete = await completeDirectDeploy(apiClient, {
+      deployId: init.deploy_id,
+      cliToken: options.cliToken,
+    });
+    return complete;
+  } catch (error) {
+    if (!isDirectUploadUnavailable(error)) {
+      throw error;
+    }
+
+    logger.dim('Direct upload unavailable; falling back to legacy deploy endpoint.');
+    return deployViaLegacyMultipart(apiClient, options);
+  }
+}
+
+async function handleDeployResult(options: {
+  response: DeployResponse;
+  pusherClient?: ForgePusherClient;
+  watch: boolean;
+}): Promise<void> {
+  const { response, pusherClient, watch } = options;
+
+  if (watch && pusherClient && response.deploy?.version_id) {
+    const d = response.deploy;
+    const renderer = new DeployRenderer(d.url, d.version_id, d.version_number);
+
+    renderer.start();
+
+    const result = await watchDeploy(pusherClient, d, renderer);
+
+    renderer.finish(result.succeeded, result.failMessage);
+
+    if (!result.succeeded) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  pusherClient?.disconnect();
+
+  if (response.deploy) {
+    handleCommandResult(response, formatDeploySuccess(response.deploy));
+  } else {
+    handleCommandResult(
+      response,
+      `Deployed successfully${response.version ? ` (version ${response.version})` : ''}.`,
+    );
+  }
+}
+
 export function registerDeployCommand(program: Command): void {
   program
     .command('deploy')
@@ -96,11 +179,14 @@ export function registerDeployCommand(program: Command): void {
     .option('-m, --message <message>', 'Version description')
     .option('-d, --directory <dir>', 'Directory to deploy')
     .option('--no-watch', 'Skip real-time deploy tracking')
+    .option('--legacy-upload', 'Upload archive via legacy multipart API endpoint')
     .option('--org <id>', ORG_OPTION_DESCRIPTION)
     .action(async (options, cmd) => {
       const parentOpts = cmd.parent?.opts() || {};
       const config = readForgeConfig();
       validateOrgOption(options.org);
+
+      const auth = resolveAuth({ token: parentOpts.token });
 
       const siteToken = await resolveSiteTokenWithFallback({
         siteToken: parentOpts.siteToken,
@@ -116,8 +202,7 @@ export function registerDeployCommand(program: Command): void {
         stored?.pusher_key &&
         stored?.pusher_channel;
 
-      // Subscribe to Pusher BEFORE submitting the deploy so we never
-      // miss events that fire immediately after the POST returns.
+      // Subscribe to Pusher before triggering deploy so we never miss early events.
       let pusherClient: ForgePusherClient | undefined;
       if (canWatch) {
         pusherClient = new ForgePusherClient(stored.pusher_key!, stored.pusher_channel!);
@@ -132,57 +217,22 @@ export function registerDeployCommand(program: Command): void {
         spin.text = 'Creating archive...';
         archivePath = await createDeployArchive(deployDir, config?.ignore);
 
-        spin.text = 'Uploading...';
-        const archiveBuffer = readFileSync(archivePath);
-        const formData = new FormData();
-        formData.append('site_tokens', siteToken);
-        if (options.message) {
-          formData.append('message', options.message);
-        }
-        formData.append(
-          'archive',
-          new Blob([archiveBuffer], { type: 'application/zip' }),
-          'deploy.zip',
-        );
-
-        const apiClient = getApiClient();
-        const response = await apiClient.post<DeployResponse>(API_PATHS.deploy, {
-          body: formData as unknown as Record<string, unknown>,
+        spin.text = 'Uploading archive...';
+        const response = await resolveDeployResponse({
+          siteToken,
+          archivePath,
+          message: options.message,
+          cliToken: auth.token,
+          legacyUpload: options.legacyUpload === true,
         });
 
         spin.stop();
 
-        if (pusherClient && response.deploy?.version_id) {
-          const d = response.deploy;
-          const renderer = new DeployRenderer(d.url, d.version_id, d.version_number);
-
-          renderer.start();
-
-          const result = await watchDeploy(pusherClient, d, renderer);
-
-          renderer.finish(result.succeeded, result.failMessage);
-
-          if (!result.succeeded) {
-            process.exitCode = 1;
-          }
-        } else {
-          pusherClient?.disconnect();
-
-          if (response.deploy) {
-            const d = response.deploy;
-            handleCommandResult(response, [
-              `Deployed Version #${d.version_number} to ${d.url}`,
-              logger.getOutputMode() === 'human'
-                ? `  Status: ${logger.statusBadge(d.status)} | Mode: ${d.mode}`
-                : '',
-            ].filter(Boolean).join('\n'));
-          } else {
-            handleCommandResult(
-              response,
-              `Deployed successfully${response.version ? ` (version ${response.version})` : ''}.`,
-            );
-          }
-        }
+        await handleDeployResult({
+          response,
+          pusherClient,
+          watch: options.watch !== false,
+        });
       } catch (err) {
         spin.stop();
         pusherClient?.disconnect();

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -9,6 +9,9 @@ export const API_PATHS = {
   sites: '/api/v2/cli/sites',
   create: '/api/v2/cli/create',
   deploy: '/api/v2/cli/deploy',
+  deployInit: '/api/v2/cli/deploy/init',
+  deployComplete: '/api/v2/cli/deploy/complete',
+  deployStatus: '/api/v2/cli/deploy', // GET/HEAD /:deploy_id/status
   redeploy: '/api/v2/cli/redeploy',
   versionsInfo: '/api/v2/cli/versions_info',
   versions: '/api/v2/cli/versions',

--- a/src/deploy/direct-upload.ts
+++ b/src/deploy/direct-upload.ts
@@ -1,0 +1,133 @@
+import { createReadStream, statSync } from 'node:fs';
+import { Readable } from 'node:stream';
+import { randomUUID } from 'node:crypto';
+import type { ApiClient } from '../api/client.js';
+import { API_PATHS } from '../config/constants.js';
+import type {
+  DeployCompleteResponse,
+  DeployInitResponse,
+  DeployResponse,
+  DeployStatusResponse,
+  DeployUploadTarget,
+} from '../api/endpoints.js';
+import { ApiError, ForgeError } from '../utils/errors.js';
+
+export interface DirectDeployInitOptions {
+  siteToken: string;
+  archivePath: string;
+  message?: string;
+  cliToken?: string;
+  idempotencyKey?: string;
+}
+
+export interface DirectDeployCompleteOptions {
+  deployId: string;
+  cliToken?: string;
+}
+
+export function isDirectUploadUnavailable(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 404 || error.status === 501 || error.status === 405;
+  }
+  return false;
+}
+
+export async function initDirectDeploy(
+  client: ApiClient,
+  options: DirectDeployInitOptions,
+): Promise<DeployInitResponse> {
+  const archiveSize = statSync(options.archivePath).size;
+
+  return client.post<DeployInitResponse>(API_PATHS.deployInit, {
+    token: options.cliToken,
+    headers: {
+      'Idempotency-Key': options.idempotencyKey ?? randomUUID(),
+    },
+    body: {
+      site_tokens: options.siteToken,
+      archive_size: archiveSize,
+      ...(options.message ? { message: options.message } : {}),
+    },
+  });
+}
+
+export async function uploadArchiveToPresignedUrl(
+  archivePath: string,
+  upload: DeployUploadTarget,
+): Promise<void> {
+  const { size } = statSync(archivePath);
+  const stream = Readable.toWeb(createReadStream(archivePath)) as ReadableStream<Uint8Array>;
+
+  const headers: Record<string, string> = {
+    'Content-Length': String(size),
+    ...(upload.headers ?? {}),
+  };
+
+  if (!headers['Content-Type'] && !headers['content-type']) {
+    headers['Content-Type'] = 'application/zip';
+  }
+
+  const response = await fetch(upload.url, {
+    method: upload.method,
+    headers,
+    body: stream,
+    duplex: 'half',
+  } as RequestInit);
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new ForgeError(
+      `Direct archive upload failed (HTTP ${response.status})${detail ? `: ${detail.trim()}` : ''}`,
+    );
+  }
+}
+
+export async function completeDirectDeploy(
+  client: ApiClient,
+  options: DirectDeployCompleteOptions,
+): Promise<DeployCompleteResponse> {
+  return client.post<DeployCompleteResponse>(`${API_PATHS.deployComplete}`, {
+    token: options.cliToken,
+    body: {
+      deploy_id: options.deployId,
+    },
+  });
+}
+
+export async function getDirectDeployStatus(
+  client: ApiClient,
+  deployId: string,
+  cliToken?: string,
+): Promise<DeployStatusResponse> {
+  return client.get<DeployStatusResponse>(`${API_PATHS.deployStatus}/${deployId}/status`, {
+    token: cliToken,
+  });
+}
+
+export async function deployViaLegacyMultipart(
+  client: ApiClient,
+  options: {
+    siteToken: string;
+    archivePath: string;
+    message?: string;
+    cliToken?: string;
+  },
+): Promise<DeployResponse> {
+  const { readFileSync } = await import('node:fs');
+  const archiveBuffer = readFileSync(options.archivePath);
+  const formData = new FormData();
+  formData.append('site_tokens', options.siteToken);
+  if (options.message) {
+    formData.append('message', options.message);
+  }
+  formData.append(
+    'archive',
+    new Blob([archiveBuffer], { type: 'application/zip' }),
+    'deploy.zip',
+  );
+
+  return client.post<DeployResponse>(API_PATHS.deploy, {
+    token: options.cliToken,
+    body: formData as unknown as Record<string, unknown>,
+  });
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,6 +10,16 @@ export class ForgeError extends Error {
   }
 }
 
+export class ApiError extends ForgeError {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message, EXIT_CODES.ERROR);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 export class AuthError extends ForgeError {
   readonly tokenExpired: boolean;
 


### PR DESCRIPTION
## Summary
- Deploy via `POST /deploy/init` → presigned S3 PUT → `POST /deploy/complete` (same path as gleo.dev)
- Stream zip from disk instead of posting through `api.getforge.com`
- Use `resolveAuth()` for CLI token on complete
- Legacy multipart `POST /deploy` fallback when direct upload unavailable (`--legacy-upload` to force)
- Add `ApiError` with HTTP status for fallback detection

## Test plan
- [x] test-site deploy to dev gallery (~8s)
- [x] gallery 21MB deploy to dev (~40s, v7 deployed)
- [x] Full deploy log streaming via Pusher (v8)
- [x] Site serves 403 (password protected) not 500 after backend fix


Made with [Cursor](https://cursor.com)